### PR TITLE
feat(proxy): optional SUMMARY rewriting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: "1.24"
+  GO_VERSION: "1.25"
 
 jobs:
   test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 env:
-  GO_VERSION: "1.24"
+  GO_VERSION: "1.25"
 
 jobs:
   release:

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ CGO_ENABLED=0 go build -ldflags="-w -s" -o ical-proxy ./server
 
 ### GET /proxy
 
-Fetches an iCalendar feed from the specified URL, applies RFC 5545 compliance fixes, and optionally filters events by date range.
+Fetches an iCalendar feed from the specified URL, applies RFC 5545 compliance fixes, and optionally filters events by date range and rewrites event summaries.
 
 **Parameters:**
 
@@ -160,6 +160,22 @@ Fetches an iCalendar feed from the specified URL, applies RFC 5545 compliance fi
 | `url` | Yes | Absolute URL | URL of the iCalendar feed to proxy |
 | `from` | No | `YYYY-MM-DD` | Start date for event filtering (inclusive) |
 | `to` | No | `YYYY-MM-DD` | End date for event filtering (inclusive) |
+| `summary_match` | No | Regular expression | Matched against every event's `SUMMARY`. Max 512 characters |
+| `summary_replace` | No | Replacement text | What `summary_match` is replaced with. Defaults to empty, i.e. strip. Capture groups are available as `$1`, `$2`, … |
+
+**SUMMARY rewriting:**
+
+Some publishers append the name of the whole calendar to every event, so a single bin collection arrives as `Altpapier| Abfuhrkalender - Landkreis Amberg-Sulzbach` — one useful word followed by fifty characters repeated identically on every event in the feed. Calendar clients render `SUMMARY` verbatim and generally offer no way to shorten it, so the text has to be fixed before it reaches them.
+
+```bash
+# Strip everything from the first pipe onwards -> "Altpapier"
+curl "http://localhost:8080/proxy?url=https://example.com/waste.ics&summary_match=%5Cs*%7C.*%24"
+
+# Keep the fraction and prefix it -> "Abfuhr: Altpapier"
+curl "http://localhost:8080/proxy?url=https://example.com/waste.ics&summary_match=%5E(%5B%5E%7C%5D%2B%3F)%5Cs*%7C.*%24&summary_replace=Abfuhr%3A%20%241"
+```
+
+Patterns use [RE2](https://github.com/google/re2/wiki/Syntax), which matches in time linear to the input and has no catastrophic backtracking, so a caller-supplied expression cannot be used to stall the server. A rewrite that would leave `SUMMARY` empty is skipped and the original text kept — an untitled event is worse than a long title.
 
 **Response:**
 

--- a/server/main.go
+++ b/server/main.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
+	"strings"
 	"time"
 
 	ics "github.com/arran4/golang-ical"
@@ -56,6 +58,13 @@ func handleProxy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Parse optional SUMMARY rewriting parameters
+	rewrite, err := parseSummaryRewrite(r.URL.Query())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	// Parse optional date filtering parameters
 	fromParam := r.URL.Query().Get("from")
 	toParam := r.URL.Query().Get("to")
@@ -101,7 +110,7 @@ func handleProxy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fixedICal, err := ProcessICalData(icalData, fromDate, toDate)
+	fixedICal, err := ProcessICalData(icalData, fromDate, toDate, rewrite)
 	if err != nil {
 		http.Error(w, "Failed to process iCal data: "+err.Error(), http.StatusBadRequest)
 		return
@@ -114,8 +123,86 @@ func handleProxy(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// ProcessICalData takes raw iCal data and returns a processed version with optional date filtering
-func ProcessICalData(icalData []byte, fromDate, toDate *time.Time) (string, error) {
+// SummaryRewrite is an optional substitution applied to every VEVENT SUMMARY.
+//
+// Some upstream feeds append the name of the whole calendar to every single
+// event, so a bin collection arrives as
+//
+//	Altpapier| Abfuhrkalender - Landkreis Amberg-Sulzbach
+//
+// which is one useful word followed by fifty characters that are identical on
+// every event in the feed. Consumers cannot fix this: the text is what the
+// publisher put in SUMMARY, and calendar clients render it verbatim.
+type SummaryRewrite struct {
+	// Pattern is matched against the existing SUMMARY.
+	Pattern *regexp.Regexp
+	// Replacement may reference capture groups as $1, $2 and so on.
+	Replacement string
+}
+
+// parseSummaryRewrite reads the summary_match and summary_replace parameters.
+// Returns nil (and no error) when no rewriting was requested.
+func parseSummaryRewrite(query url.Values) (*SummaryRewrite, error) {
+	match := query.Get("summary_match")
+	replace := query.Get("summary_replace")
+
+	if match == "" {
+		if replace != "" {
+			return nil, fmt.Errorf("'summary_replace' requires 'summary_match'")
+		}
+		return nil, nil
+	}
+
+	// Bounded so a pathological pattern cannot be handed to the compiler.
+	// Matching itself is safe regardless: Go's regexp is RE2, which runs in
+	// time linear in the input and has no catastrophic backtracking.
+	const maxPatternLen = 512
+	if len(match) > maxPatternLen {
+		return nil, fmt.Errorf("'summary_match' must be at most %d characters", maxPatternLen)
+	}
+
+	pattern, err := regexp.Compile(match)
+	if err != nil {
+		return nil, fmt.Errorf("invalid 'summary_match' expression: %w", err)
+	}
+
+	return &SummaryRewrite{Pattern: pattern, Replacement: replace}, nil
+}
+
+// rewriteSummaries applies the substitution to every event's SUMMARY and
+// returns the number of events changed.
+//
+// An event whose rewritten SUMMARY would be empty is left alone. Trading a
+// too-long title for no title at all is not an improvement, and it would strip
+// a property that RFC 5545 expects to carry the event's display text.
+func rewriteSummaries(calendar *ics.Calendar, rewrite *SummaryRewrite) int {
+	if rewrite == nil {
+		return 0
+	}
+
+	changed := 0
+	for _, event := range calendar.Events() {
+		prop := event.GetProperty(ics.ComponentPropertySummary)
+		if prop == nil {
+			continue
+		}
+
+		original := prop.Value
+		rewritten := strings.TrimSpace(rewrite.Pattern.ReplaceAllString(original, rewrite.Replacement))
+		if rewritten == "" || rewritten == original {
+			continue
+		}
+
+		event.SetProperty(ics.ComponentPropertySummary, rewritten)
+		changed++
+	}
+
+	return changed
+}
+
+// ProcessICalData takes raw iCal data and returns a processed version with
+// optional date filtering and optional SUMMARY rewriting
+func ProcessICalData(icalData []byte, fromDate, toDate *time.Time, rewrite *SummaryRewrite) (string, error) {
 	if len(icalData) == 0 {
 		return "", fmt.Errorf("empty iCal data")
 	}
@@ -130,6 +217,12 @@ func ProcessICalData(icalData []byte, fromDate, toDate *time.Time) (string, erro
 	// Apply date filtering if specified
 	if fromDate != nil || toDate != nil {
 		filterEventsByDate(calendar, fromDate, toDate)
+	}
+
+	// Rewrite summaries before the compliance pass, so the fixer sees the
+	// text that will actually be served.
+	if changed := rewriteSummaries(calendar, rewrite); changed > 0 {
+		log.Printf("Rewrote SUMMARY on %d event(s)", changed)
 	}
 
 	// Apply comprehensive fixes to ensure RFC 5545 compliance
@@ -207,7 +300,7 @@ func parseEventDate(dateStr string) (time.Time, error) {
 
 // FixICalData is kept for backward compatibility but now uses ProcessICalData
 func FixICalData(icalData []byte) (string, error) {
-	return ProcessICalData(icalData, nil, nil)
+	return ProcessICalData(icalData, nil, nil, nil)
 }
 
 // handleHealth provides a simple health check endpoint

--- a/server/main.go
+++ b/server/main.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -19,14 +20,28 @@ func main() {
 	http.HandleFunc("/proxy", handleProxy)
 	http.HandleFunc("/health", handleHealth)
 
-	port := os.Getenv("PORT")
-	if port == "" {
-		port = "8080"
+	// PORT is validated into an int rather than used as a string. It came
+	// straight from the environment into both the listen address and a log
+	// line, which gosec flags as log injection (G706): anything in PORT is
+	// reproduced verbatim in the log, newlines included, so a value like
+	// "8080\nFATAL forged entry" writes a second line of its own.
+	//
+	// Parsing it settles that at the source. A port is a number, an
+	// unparseable one is a misconfiguration worth failing on rather than
+	// quietly ignoring, and once it is an int there is nothing left to
+	// inject — the log below formats %d.
+	port := 8080
+	if raw := os.Getenv("PORT"); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed < 1 || parsed > 65535 {
+			log.Fatalf("Invalid PORT: expected an integer between 1 and 65535")
+		}
+		port = parsed
 	}
 
 	// Create server with timeouts to address gosec G114
 	server := &http.Server{
-		Addr:           ":" + port,
+		Addr:           fmt.Sprintf(":%d", port),
 		Handler:        nil,
 		ReadTimeout:    10 * time.Second,
 		WriteTimeout:   10 * time.Second,
@@ -34,9 +49,9 @@ func main() {
 		MaxHeaderBytes: 1 << 20, // 1 MB
 	}
 
-	fmt.Printf("Starting server on port %s\n", port)
+	fmt.Printf("Starting server on port %d\n", port)
 	if err := server.ListenAndServe(); err != nil {
-		log.Fatalf("Failed to start server on port %s: %v", port, err)
+		log.Fatalf("Failed to start server on port %d: %v", port, err)
 	}
 }
 
@@ -55,6 +70,15 @@ func handleProxy(w http.ResponseWriter, r *http.Request) {
 	parsedURL, err := url.Parse(urlParam)
 	if err != nil || !parsedURL.IsAbs() {
 		http.Error(w, "Invalid 'url' parameter", http.StatusBadRequest)
+		return
+	}
+
+	// Restrict the scheme. Absolute is not enough: url.Parse happily accepts
+	// file:///etc/passwd and ftp://, and net/http would follow whatever it
+	// has a transport for. A calendar feed is fetched over HTTP or HTTPS and
+	// nothing else.
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		http.Error(w, "Invalid 'url' parameter: only http and https are supported", http.StatusBadRequest)
 		return
 	}
 
@@ -93,6 +117,14 @@ func handleProxy(w http.ResponseWriter, r *http.Request) {
 	client := &http.Client{
 		Timeout: 30 * time.Second,
 	}
+	// #nosec G704 -- fetching a caller-supplied URL is what this service is
+	// for; a proxy that only fetched a fixed address would not be a proxy.
+	// The request is constrained to what that job needs: the URL must be
+	// absolute and http/https (checked above), the client has a 30s timeout,
+	// and the response is parsed as iCalendar rather than returned raw.
+	// Anything further — an upstream allowlist, or refusing private address
+	// ranges — is a deployment decision, and this one runs behind a
+	// CiliumNetworkPolicy that already bounds where it may connect.
 	resp, err := client.Get(urlParam)
 	if err != nil || resp.StatusCode != http.StatusOK {
 		http.Error(w, "Failed to fetch iCal file", http.StatusInternalServerError)

--- a/server/main_test.go
+++ b/server/main_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -1202,6 +1203,146 @@ func TestProxyEndpointErrors(t *testing.T) {
 			responseBody := w.Body.String()
 			if !strings.Contains(responseBody, tc.expectedMsg) {
 				t.Errorf("Expected error message containing '%s', got '%s'", tc.expectedMsg, responseBody)
+			}
+		})
+	}
+}
+
+// wasteCalendarServer serves a feed shaped like the real one this feature was
+// written for: every event's SUMMARY carries the fraction followed by the name
+// of the whole calendar. Note the two spacings around the pipe — the upstream
+// is inconsistent about it, so the pattern has to tolerate both.
+func wasteCalendarServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		icalData := "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Test//EN\r\n" +
+			"BEGIN:VEVENT\r\nUID:1@test.local\r\nDTSTART:20260814T060000Z\r\nDTEND:20260814T070000Z\r\n" +
+			"SUMMARY:Altpapier| Abfuhrkalender - Landkreis Amberg-Sulzbach\r\nEND:VEVENT\r\n" +
+			"BEGIN:VEVENT\r\nUID:2@test.local\r\nDTSTART:20260821T060000Z\r\nDTEND:20260821T070000Z\r\n" +
+			"SUMMARY:Restmüll | Abfuhrkalender - Landkreis Amberg-Sulzbach\r\nEND:VEVENT\r\n" +
+			"END:VCALENDAR"
+		w.Header().Set("Content-Type", "text/calendar")
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte(icalData)); err != nil {
+			t.Errorf("Failed to write test response: %v", err)
+		}
+	}))
+}
+
+func TestHandleProxySummaryRewrite(t *testing.T) {
+	upstream := wasteCalendarServer(t)
+	defer upstream.Close()
+
+	// Strip from the pipe onwards, tolerating the space the feed sometimes
+	// puts before it.
+	target := "/proxy?url=" + url.QueryEscape(upstream.URL) +
+		"&summary_match=" + url.QueryEscape(`\s*\|.*$`)
+
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	w := httptest.NewRecorder()
+	handleProxy(w, req)
+
+	if w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("Expected status OK, got %v", w.Result().Status)
+	}
+
+	body := w.Body.String()
+	for _, want := range []string{"SUMMARY:Altpapier", "SUMMARY:Restmüll"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("Expected rewritten %q in response, got:\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, "Abfuhrkalender") {
+		t.Errorf("Expected the calendar name to be stripped from every SUMMARY, got:\n%s", body)
+	}
+}
+
+func TestHandleProxySummaryRewriteWithCaptureGroup(t *testing.T) {
+	upstream := wasteCalendarServer(t)
+	defer upstream.Close()
+
+	target := "/proxy?url=" + url.QueryEscape(upstream.URL) +
+		"&summary_match=" + url.QueryEscape(`^([^|]+?)\s*\|.*$`) +
+		"&summary_replace=" + url.QueryEscape(`Abfuhr: $1`)
+
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	w := httptest.NewRecorder()
+	handleProxy(w, req)
+
+	body := w.Body.String()
+	if !strings.Contains(body, "SUMMARY:Abfuhr: Altpapier") {
+		t.Errorf("Expected capture group substitution, got:\n%s", body)
+	}
+}
+
+// A rewrite that empties the SUMMARY must be ignored rather than applied.
+// Serving an event with no title is worse than serving a long one.
+func TestHandleProxySummaryRewriteKeepsNonEmpty(t *testing.T) {
+	upstream := wasteCalendarServer(t)
+	defer upstream.Close()
+
+	target := "/proxy?url=" + url.QueryEscape(upstream.URL) +
+		"&summary_match=" + url.QueryEscape(`.*`)
+
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	w := httptest.NewRecorder()
+	handleProxy(w, req)
+
+	body := w.Body.String()
+	if !strings.Contains(body, "SUMMARY:Altpapier| Abfuhrkalender - Landkreis Amberg-Sulzbach") {
+		t.Errorf("Expected the original SUMMARY to survive an emptying rewrite, got:\n%s", body)
+	}
+}
+
+func TestParseSummaryRewrite(t *testing.T) {
+	testCases := []struct {
+		name      string
+		query     string
+		expectNil bool
+		expectErr string
+	}{
+		{name: "absent", query: "", expectNil: true},
+		{name: "match only", query: "summary_match=" + url.QueryEscape(`\|.*$`)},
+		{
+			name:      "replace without match",
+			query:     "summary_replace=x",
+			expectErr: "requires 'summary_match'",
+		},
+		{
+			name:      "invalid expression",
+			query:     "summary_match=" + url.QueryEscape(`([`),
+			expectErr: "invalid 'summary_match'",
+		},
+		{
+			name:      "over-long expression",
+			query:     "summary_match=" + strings.Repeat("a", 513),
+			expectErr: "at most 512 characters",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			values, err := url.ParseQuery(tc.query)
+			if err != nil {
+				t.Fatalf("bad test query: %v", err)
+			}
+
+			rewrite, err := parseSummaryRewrite(values)
+
+			if tc.expectErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.expectErr) {
+					t.Fatalf("Expected error containing %q, got %v", tc.expectErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if tc.expectNil && rewrite != nil {
+				t.Errorf("Expected no rewrite, got %+v", rewrite)
+			}
+			if !tc.expectNil && rewrite == nil {
+				t.Error("Expected a rewrite, got nil")
 			}
 		})
 	}

--- a/server/main_test.go
+++ b/server/main_test.go
@@ -1347,3 +1347,28 @@ func TestParseSummaryRewrite(t *testing.T) {
 		})
 	}
 }
+
+// Absolute is not the same as fetchable: url.Parse accepts file:// and ftp://
+// happily, and net/http would follow anything it has a transport for.
+func TestHandleProxyRejectsNonHTTPSchemes(t *testing.T) {
+	testCases := []string{
+		"file:///etc/passwd",
+		"ftp://example.com/calendar.ics",
+		"gopher://example.com/",
+	}
+
+	for _, target := range testCases {
+		t.Run(target, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/proxy?url="+url.QueryEscape(target), nil)
+			w := httptest.NewRecorder()
+			handleProxy(w, req)
+
+			if w.Result().StatusCode != http.StatusBadRequest {
+				t.Errorf("Expected 400 for %q, got %v", target, w.Result().Status)
+			}
+			if !strings.Contains(w.Body.String(), "only http and https") {
+				t.Errorf("Expected a scheme error for %q, got %q", target, w.Body.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Some publishers append the name of the whole calendar to every event, so a single bin collection arrives as

    Altpapier| Abfuhrkalender - Landkreis Amberg-Sulzbach

which is one useful word followed by fifty characters that are identical on every event in the feed. Consumers cannot fix this. The text is what the publisher put in SUMMARY, calendar clients render it verbatim, and the ones that do not offer a title transform — Home Assistant's calendar cards among them — have no way out. In a narrow column it wraps to three lines per event.

/proxy takes two new parameters:

    summary_match     regular expression matched against SUMMARY
    summary_replace   what to replace it with, default empty

For the feed above, summary_match=\s*\|.*$ yields "Altpapier". The same pattern also handles "Restmüll | ..." where that publisher puts a space before the pipe. Capture groups are available as $1, $2 and so on.

Rewriting happens before the compliance pass so the fixer sees the text that will actually be served.

Notes on the edges:

- summary_replace without summary_match is a 400 rather than a silent no-op, since it can only be a mistake.
- Patterns are capped at 512 characters. Matching itself is safe at any length: Go's regexp is RE2, linear in the input with no catastrophic backtracking, so a caller-supplied expression cannot stall the server.
- A rewrite that would leave SUMMARY empty is skipped and the original kept. An untitled event is worse than a long title, and SUMMARY is where RFC 5545 expects the display text to live.

FixICalData keeps its signature and passes nil.